### PR TITLE
Youtube playlist only page will now add videos (not only when you're viewing a video in that playlist)

### DIFF
--- a/js/remote.js
+++ b/js/remote.js
@@ -352,6 +352,8 @@ function initYouTubeList(){
         if (youTubeListId){
             extractVideosFromYouTubePlaylist(youTubeListId);
             queueListButton.attr('disabled', false);
+            queueListButton.parent().removeClass('disabled');
+
         } else {
             queueListButton.attr('disabled', true);
         }

--- a/js/shared.js
+++ b/js/shared.js
@@ -68,7 +68,7 @@ function getCurrentUrl(callback) {
 }
 
 function getURLParameter(tabUrl, sParam) {
-    var sPageURL = tabUrl;
+    var sPageURL = tabUrl.substring(tabUrl.indexOf('?') + 1 );
     var sURLVariables = sPageURL.split('&');
     for (var i = 0; i < sURLVariables.length; i++) {
         var sParameterName = sURLVariables[i].split('=');


### PR DESCRIPTION
Not sure how you wanted your url variables to be used to I fixed it closest to the url parsing as I could.

You mistook the full url to be a url of just the search parameters, causing the first parameter checked to always fail (splitting the whole url with & which leads to the first param being http://bla... etc).

In a page like this http://www.youtube.com/playlist?list=PLF8274AC20DA0CA18, it means it won't trigger.

Second, even if it did, the button would work but style would keep it looking greyed out so i changed the parent <li> element to become non disabled as well.

Additionally, sort of in relation to this bug, chrome.tabs.getselected is deprecated. It still works for the time being however
