### PR TITLE
Don't call youtube api if there's no embedded video

### DIFF
--- a/js/content_scripts/embedded-video-content-scripts.js
+++ b/js/content_scripts/embedded-video-content-scripts.js
@@ -23,6 +23,10 @@ function getEmbeddedVideos(callback) {
             videoIdList.push(obj.src.match(regex)[1]);
         }
     }
+    
+    if (videoIdList.length === 0) {
+        return;
+    }
 
     var url = "https://www.googleapis.com/youtube/v3/videos?part=snippet&id=" + combineVideoIdList(videoIdList) + "&key=AIzaSyA3INgfTLddMbrJm8f68xpvfPZDAzDqk10";
     $.getJSON(url, function (data) {


### PR DESCRIPTION
Single commit to remove an annoying bug.
getEmbeddedVideos should return early when no embedded videos are available

Thanks for taking this PR in consideration.
