### PR TITLE
Don't call "element.href" for SVG compatibility.

### DIFF
--- a/js/content_scripts/context-menu-content-scripts.js
+++ b/js/content_scripts/context-menu-content-scripts.js
@@ -14,7 +14,7 @@ function addContextMenuTo(selector) {
             for (var i = 0; i < event.path.length; i++) {
                 var element = event.path[i];
                 if (element[matches] && element[matches]('a')) {
-                    createContextMenu(element.href);
+                    createContextMenu(element.getAttribute("href"));
                     isHovering = true;
                     break;
                 }


### PR DESCRIPTION
- In SVG, element.href returns SVGAnimatedString.
- see: http://stackoverflow.com/questions/12588913/svganimatedstring-missing-method-indexof