### PR TITLE
Update Yle Areena patterns.

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -478,7 +478,10 @@ var YoutubeModule = {
 var YleAreenaModule = {
     canHandleUrl: function(url) {
         var validPatterns = [
-            "^(https|http)://areena.yle.fi/tv/*"
+            "^(https|http)://areena.yle.fi/1-*",
+            "^(https|http)://areena.yle.fi/tv/suorat/*",
+            "^(https|http)://areena-v3.yle.fi/tv*",
+            "^(https|http)://areena-v3.yle.fi/tv/suora/*"
         ];
         return urlMatchesOneOfPatterns(url, validPatterns);
     },


### PR DESCRIPTION
The old v3 site video links work with the current addon as it is based on the old site. Old site live stream = error. New site video links = error as well, the areena addon needs modifications.