### PR TITLE
Match selectedHost with profile id, not with index

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -318,6 +318,7 @@ function deleteThisProfile() {
         var profile = allProfiles[i];
         if (profile.id == selectedId) {
             indexToRemove = i;
+            break;
         }
     }
 

--- a/js/remote.js
+++ b/js/remote.js
@@ -11,8 +11,11 @@ function hasUrlSetup() {
             var profiles = JSON.parse(allProfiles);
 
             if (selectedHost != null && selectedHost > 0) {
-                if (profiles[selectedHost] != null) {
-                    return profiles[selectedHost].url != null && profiles[selectedHost].url != '' && profiles[selectedHost].port != null && profiles[selectedHost].port != '';
+                for (var i = 0; i < profiles.length; i++) {
+                    var profile = profiles[i];
+                    if (profile.id == selectedHost) {
+                        return profile.url != null && profile.url != '' && profile.port != null && profile.port != '';
+                    }
                 }
             } else {
                 return profiles[0].url != null && profiles[0].url != '' && profiles[0].port != null && profiles[0].port != '';


### PR DESCRIPTION
`hasUrlSetup` did a profile lookup by index, instead of looking for the matching id. This breaks when the index of a profile changes (i.e., when a profile before it is deleted).

Sorry, didn't test this (but I did observe the bug).
