### PR TITLE
updated youtube module with recommended 'play' path

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -458,12 +458,12 @@ var YoutubeModule = {
     getPluginPath: function(url, getAddOnVersion, callback) {
         if (url.match('v=([^&]+)')) {
             var videoId = url.match('v=([^&]+)')[1];
-            callback('plugin://plugin.video.youtube/?action=play_video&videoid=' + videoId);
+            callback('plugin://plugin.video.youtube/play/?video_id=' + videoId);
         }
 
         if (url.match('.*youtu.be/(.+)')) {
             var videoId = url.match('.*youtu.be/(.+)')[1];
-            callback('plugin://plugin.video.youtube/?action=play_video&videoid=' + videoId);
+            callback('plugin://plugin.video.youtube/play/?video_id=' + videoId);
         }
     },
     createCustomContextMenus: function() {


### PR DESCRIPTION
YouTube call updated with new recommended path.

Avoid messages such as:

```
16:28:48 T:140295560738560 WARNING: [plugin.video.youtube] DEPRECATED "plugin://plugin.video.youtube/?action=play_video&videoid=<ID>"
16:28:48 T:140295560738560 WARNING: [plugin.video.youtube] USE INSTEAD "plugin://plugin.video.youtube/play/?video_id=<ID>"
```

https://github.com/Kolifanes/plugin.video.youtube/blob/4dde9c910f7dbf548e2dfc59a192fb75ac147dfb/resources/lib/youtube/helper/yt_old_actions.py#L6
