### PR TITLE
Update Facebook video regex

### DIFF
--- a/js/content_scripts/facebook-content-scripts.js
+++ b/js/content_scripts/facebook-content-scripts.js
@@ -3,9 +3,9 @@ chrome.extension.onMessage.addListener(
     function(request, sender, sendResponse) {
         if ("getFacebookVideoUrl" == request.action) {
             try {
-            var videoLink = $('html').html().match('hd_src_no_ratelimit":"([^"]*)')[1];
+            var videoLink = $('html').html().match('hd_src_no_ratelimit"?:"([^"]*)')[1];
             } catch (e) {
-                videoLink = $('html').html().match('sd_src_no_ratelimit":"([^"]*)')[1];
+                videoLink = $('html').html().match('sd_src_no_ratelimit"?:"([^"]*)')[1];
             }
             if (videoLink) {
               sendResponse({url: videoLink});


### PR DESCRIPTION
At least in .au, there is no longer a " after ratelimit (see https://www.facebook.com/abcqanda/videos/10154336391111831/). Updated regex will match both forms.