### PR TITLE
[#121] Workaround solution for event.target[matches] is not a func...

### DIFF
--- a/js/content_scripts/context-menu-content-scripts.js
+++ b/js/content_scripts/context-menu-content-scripts.js
@@ -20,7 +20,7 @@ function addContextMenuTo(selector) {
 
     var isHovering = false;
     document.addEventListener('mouseover', function(event) {
-        if (event.target && event.target[matches](selector)) {
+        if (event.target && $.isFunction(event.target[matches]) && event.target[matches](selector)) {
             if (!event.path) {
                 console.log("Using workaround to get event.path");
                 event.path = getEventPath(event);


### PR DESCRIPTION
I did a small update that adds a check if event.target[matches] is actually a function and that prevets from triggering error.