### PR TITLE
[Firefox] Mouse scroll wheel doesn't move volume slider

### DIFF
--- a/js/remote.js
+++ b/js/remote.js
@@ -556,10 +556,11 @@ function initVolumeSlider() {
         });
     });
 
-    $('#volume_control').bind("mousewheel", function (e) {
+    $('#volume_control').bind("wheel", function (wheelEvent) {
+        let e = wheelEvent.originalEvent;
         var $volumecontrol = $('#volume_control');
         var addDiff = 1;
-        var diff = e.originalEvent.timeStamp - lastRecordedWheelTime;
+        var diff = e.timeStamp - lastRecordedWheelTime;
         if (diff < 10) {
             addDiff+=15;
         } else if (diff < 100) {
@@ -567,13 +568,13 @@ function initVolumeSlider() {
         } else if (diff < 150) {
             addDiff+=2;
         }
-        if (e.originalEvent.wheelDelta > 0) {
+        if (e.deltaY > 0) {
             $volumecontrol.slider("value", $volumecontrol.slider("value") + addDiff);
         } else {
             $volumecontrol.slider("value", $volumecontrol.slider("value") - addDiff);
         }
 
-        lastRecordedWheelTime = e.originalEvent.timeStamp;
+        lastRecordedWheelTime = e.timeStamp;
     });
 }
 

--- a/options.html
+++ b/options.html
@@ -109,6 +109,12 @@
                     <div class="tab-pane" id="changelist">
                         <div style="margin: 0 25px">
                             <p>
+                                <strong>Update 1.9.1</strong>
+                                <ul>
+                                    <li>Fixed volume adjustment using mouse wheel(Firefox)</li>
+                                </ul>
+                            </p>
+                            <p>
                                 <strong>Update 1.9.0</strong>
                                 <ul>
                                     <li>Fixed Facebook video support (with help from predakanga)</li>


### PR DESCRIPTION
The problem is caused by the 'mousewheel' event being deprecated.
```
    Non-standard
    This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.```

I changed the volume slider code to use 'wheel' event.