### PR TITLE
Initialize slider with default values before calling initWatchdog()

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -1,10 +1,11 @@
 $(document).ready( function() {
     initFocusFix();
+    initSeekerSlider(false);
     initWatchdog();
     initProfiles();
     initConnectivity(function() {
         initJsonVersion();
-        initSeekerSlider();
+        initSeekerSlider(true);
         initVolumeSlider();
         initKeyBindings();
 

--- a/js/remote.js
+++ b/js/remote.js
@@ -577,37 +577,43 @@ function initVolumeSlider() {
     });
 }
 
-function initSeekerSlider() {
+function initSeekerSlider(connected) {
     var $seeker = $('#seeker');
     $seeker.slider({
         animate: 'fast',
         orientation: "horizontal",
         range: "min",
         min: 0,
-        start: function(event, ui) {
-            clearInterval(watchdog);
-            $('#scrollerTime').show();
-        },
-        slide: function (event, ui) {
-            $(document).bind('mousemove', function(e) {
-                var $scrollerTime = $('#scrollerTime');
-                $scrollerTime.css({
-                    left: e.pageX + 18,
-                    top: e.pageY + 8
-                });
-                $scrollerTime.html(formatSeconds(ui.value));
-            });
-        },
-        stop: function (event, ui) {
-            initWatchdog();
-            getActivePlayerId(function (playerId) {
-                if (playerId == 0 || playerId == 1) {
-                    seek(playerId, ui.value);
-                }
-            });
-            $('#scrollerTime').hide();
-        }
+        value: 0,
+        disabled: true
     });
+    if (connected) {
+        $seeker.slider({
+            start: function(event, ui) {
+                clearInterval(watchdog);
+                $('#scrollerTime').show();
+            },
+            slide: function (event, ui) {
+                $(document).bind('mousemove', function(e) {
+                    var $scrollerTime = $('#scrollerTime');
+                    $scrollerTime.css({
+                        left: e.pageX + 18,
+                        top: e.pageY + 8
+                    });
+                    $scrollerTime.html(formatSeconds(ui.value));
+                });
+            },
+            stop: function (event, ui) {
+                initWatchdog();
+                getActivePlayerId(function (playerId) {
+                    if (playerId == 0 || playerId == 1) {
+                        seek(playerId, ui.value);
+                    }
+                });
+                $('#scrollerTime').hide();
+            }
+        });
+    }
 
     getActivePlayerId(function (playerId, type) {
         if (playerId == 0 || playerId == 1) {


### PR DESCRIPTION
When the addon is not connected to Kodi, the error appears in the logs when opening the remote page.

```
Error: cannot call methods on slider prior to initialization; attempted to call method 'value'  jquery-2.1.4.min.js:2:1821
	error moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/jquery-2.1.4.min.js:2:1821
	e.widget.bridge/e.fn[t]/< moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/jquery-ui-1.11.4.min.js:6:9073
	each moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/jquery-2.1.4.min.js:2:2880
	each moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/jquery-2.1.4.min.js:2:845
	e.widget.bridge/e.fn[t] moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/jquery-ui-1.11.4.min.js:6:8812
	initWatchdog/watchdog< moz-extension://3dbca519-d1fb-43d8-979a-dc1b00563750/js/remote.js:299:27```