### PR TITLE
Handle Arte's video (The European Culture Channel)

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,7 @@ Supported websites include
  * Acestream
  * AnimeLab
  * ARD Mediathek (German TV Station)
+ * Arte (The European Culture Channel)
  * Cda.pl
  * CollegeHumor
  * DailyMotion

--- a/js/modules.js
+++ b/js/modules.js
@@ -58,6 +58,23 @@ var ArdMediaThekModule = {
     }
 };
 
+var ArteModule = {
+    canHandleUrl: function(url) {
+        var validPatterns = [
+            'https://www.arte.tv/(fr|de|en|es|pl|it)/videos/*'
+        ];
+        return urlMatchesOneOfPatterns(url, validPatterns);
+    },
+    getMediaType: function() {
+        return 'video';
+    },
+    getPluginPath: function(url, getAddOnVersion, callback) {
+        var kind='SHOW';
+        var program_id=url.match('/videos/(.*)/.*/')[1]; 
+        callback('plugin://plugin.video.arteplussept/play/' + kind + '/' + program_id);
+    }
+};
+
 var CdaModule = {
     canHandleUrl: function(url) {
         var validPatterns = [
@@ -897,6 +914,7 @@ var allModules = [
     AcestreamModule,
     AnimeLabModule,
     ArdMediaThekModule,
+    ArteModule,
     CdaModule,
     CollegeHumorModule,
     DailyMotionModule,

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 2,
-    "version": "1.9.1",
+    "version": "1.9.2",
     "name": "Play to Kodi",
     "description": "Play, queue and remote control your favourite online media on Kodi / XBMC.",
     "applications": {


### PR DESCRIPTION
#170 Support now  playing videos of the [European Arte Culture Channel](https://www.arte.tv/f) using the [Arte+7](https://github.com/known-as-bmf/plugin.video.arteplussept) plugin for Kodi.