### PR TITLE
Add support for Vier,Vijf and Zes using plugin.video.viervijfzes

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -727,6 +727,24 @@ var VesselLabModule = {
     }
 };
 
+var VierVijfZesModule = {
+    canHandleUrl: function(url) {
+        var validPatterns = [
+            ".*(vier|vijf|zes)(tv)?\.be/(video/.*)"
+        ];
+        return urlMatchesOneOfPatterns(url, validPatterns);
+    },
+    getMediaType: function() {
+        return 'video';
+    },
+    getPluginPath: function(url, getAddOnVersion, callback) {
+        let regex = ".*(vier|vijf|zes)(tv)?\.be/(video/.*)";
+        let channel = url.match(regex)[1];
+        let page = url.match(regex)[3];
+        callback('plugin://plugin.video.viervijfzes/play/page/' + channel + '/' + encodeURIComponent(page));
+    }
+};
+
 var VimeoModule = {
     canHandleUrl: function(url) {
         var validPatterns = [
@@ -929,6 +947,7 @@ var allModules = [
     TwitchTvModule,
     UrgantShowModule,
     VesselLabModule,
+    VierVijfZesModule,
     VimeoModule,
     VivoModule,
     XnxxModule,


### PR DESCRIPTION
This patch adds support for the video-on-demand content by SBS Belgium (Flemish commercial broadcaster) available on vier.be, vijf.be and zes.be using https://github.com/add-ons/plugin.video.viervijfzes